### PR TITLE
Update slop_test.rb

### DIFF
--- a/test/slop_test.rb
+++ b/test/slop_test.rb
@@ -1,29 +1,29 @@
 # frozen-string-literal: true
 
-require "test_helper"
+require 'test_helper'
 
 describe Slop do
-  describe ".parse" do
-    it "parses a list of arguments" do
+  describe '.parse' do
+    it 'parses a list of arguments' do
       result = Slop.parse(%w[--name Lee]) do |o|
-        o.string "--name"
+        o.string '--name'
       end
 
-      assert_equal "Lee", result[:name]
+      assert_equal 'Lee', result[:name]
     end
   end
 
-  describe ".option_defined?" do
-    it "handles bad constant names" do
-      assert_equal false, Slop.option_defined?("Foo?Bar")
+  describe '.option_defined?' do
+    it 'handles bad constant names' do
+      refute Slop.option_defined?('Foo?Bar')
     end
 
-    it "returns false if the option is not defined" do
-      assert_equal false, Slop.option_defined?("FooBar")
+    it 'returns false if the option is not defined' do
+      refute Slop.option_defined?('FooBar')
     end
 
-    it "returns true if the option is defined" do
-      assert_equal true, Slop.option_defined?("String")
+    it 'returns true if the option is defined' do
+      assert Slop.option_defined?('String')
     end
   end
 end


### PR DESCRIPTION
1.Quoting Style: Switched double quotes to single quotes where interpolation wasn't needed. 2.Refactor Boolean Assertions:
Changed assert_equal false to refute (better readability and idiomatic). Changed assert_equal true to assert.
3.Consistency: The code follows the Ruby community conventions for test clarity and style.